### PR TITLE
fixing page content alignment

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -12,7 +12,7 @@ body {
 
 .content{
     text-align: center;
-    width:95%;
+    width: 100%;
 }
 
 h1 {


### PR DESCRIPTION
The content was using 95% width, causing to automatically add a margin right. So setting it to 100% fix the alignment. Also, it could be no width attribute specified due to text-align center.